### PR TITLE
add/propagate quiet flag

### DIFF
--- a/safetensors_util.py
+++ b/safetensors_util.py
@@ -13,6 +13,8 @@ force_overwrite_flag=click.option("-f","--force-overwrite",default=False,is_flag
                                   help="overwrite existing files")
 fix_ued_flag=click.option("-pm","--parse-more",default=False,is_flag=True, show_default=True,
                           help="when printing metadata, unescaped doublequotes to make text more readable" )
+quiet_flag=click.option("-q","--quiet",default=False,is_flag=True, show_default=True,
+                        help="when printing metadata, only print json" )
 
 @click.group()
 
@@ -33,9 +35,11 @@ def cmd_header(ctx,input_file:str) -> int:
 @cli.command(name="metadata",short_help="print only __metadata__ in file header")
 @readonly_input_file
 @fix_ued_flag
+@quiet_flag
 @click.pass_context
-def cmd_meta(ctx,input_file:str,parse_more:bool)->int:
+def cmd_meta(ctx,input_file:str,parse_more:bool,quiet:bool)->int:
     ctx.obj['parse_more'] = parse_more
+    ctx.obj['quiet'] = quiet
     sys.exit( safetensors_worker.PrintMetadata(ctx.obj,input_file) )
 
 @cli.command(name="listkeys",short_help="print header key names (except __metadata__) as a Python list")

--- a/safetensors_worker.py
+++ b/safetensors_worker.py
@@ -106,7 +106,7 @@ def _ParseMore(d:dict):
             _ParseMore(value)
 
 def PrintMetadata(cmdLine:dict,input_file:str) -> int:
-    s=SafeTensorsFile.open_file(input_file)
+    s=SafeTensorsFile.open_file(input_file,cmdline["quiet"])
     js=s.get_header()
     if js is None: return -1
 

--- a/safetensors_worker.py
+++ b/safetensors_worker.py
@@ -106,7 +106,7 @@ def _ParseMore(d:dict):
             _ParseMore(value)
 
 def PrintMetadata(cmdLine:dict,input_file:str) -> int:
-    s=SafeTensorsFile.open_file(input_file,cmdline["quiet"])
+    s=SafeTensorsFile.open_file(input_file,cmdLine["quiet"])
     js=s.get_header()
     if js is None: return -1
 


### PR DESCRIPTION
This adds a quiet flag to make the output truly json; saves skipping the first line.

```bash
f=/path/to/file.safetensors

python safetensors_util/safetensors_util.py metadata $f -pm | jq '.__metadata__.ss_tag_frequency'
parse error: Invalid numeric literal at line 1, column 43

# before the change required:
python safetensors_util/safetensors_util.py metadata $f -pm | sed -n '1b;p' | jq '.__metadata__.ss_tag_frequency'

# after the change you can do:
python safetensors_util/safetensors_util.py metadata $f -pm -q | jq '.__metadata__.ss_tag_frequency'
```

considerations
There could be more subcommands that could benefit from  quiet flag, maybe.
Alternatively the safetensors info could be printed to stderr, not stdout. 


Useful repo by the way. I was trying to get the header using:

`cut -b 8- ${safetensors_file} | grep -m 1 -aPo '^[^\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x8F]+\}' | json_pp`

that kind of worked, but not always.