### PR TITLE
Quick example (Windows CMD to JSON file)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+logs
+__pycache__

--- a/readme.md
+++ b/readme.md
@@ -62,3 +62,11 @@ You can create a JSON file containing a \_\_metadata\_\_ entry:
 and write it to safetensors file header using the writemd command:
 
         python safetensors_util.py writemd input.safetensors input.json output.safetensors
+
+For Windows user (CMD), to output the header files into a JSON file:
+
+        python safetensors_util.py metadata "C:\SD_DIR\models\Lora\YOUR_LORA.safetensors" | sed "1 d" >> logs/result.json
+
+Meanwhile this can be used in some base models (e.g. SDXL based finetune, SD 1.X probably don't, SD 2.X can refer to bundled yaml):
+
+        python safetensors_util.py metadata "C:\SD_DIR\models\Stable-diffusion\SDXL_FT.safetensors" | sed "1 d" >> logs/result.json


### PR DESCRIPTION
Thank you for the tiny script!

I spent some time to figure out the working command, and somehow skipped the python code and directly trim the first line and redirect the output to a standalone JSON file.

I was doing some quick research on resolution / ARB selection on fine tuned checkpoints, especially the older 1.X models. Looks like I didn't get what I've wanted, but I've found something else.